### PR TITLE
#15 - Update the usage of HTTPResponse.readline() to HTTPResponse.rea…

### DIFF
--- a/ssbu_amiibo/amiibo_class.py
+++ b/ssbu_amiibo/amiibo_class.py
@@ -115,7 +115,7 @@ class ssbu:
 		req = urllib.request.Request('https://www.amiiboapi.com/api/amiibo/?id='+self.ID)
 		try:
 			with urllib.request.urlopen(req) as response:
-				result = json.loads(response.readline().decode("utf-8"))
+				result = json.loads(response.read().decode("utf-8"))
 				self.webdata = result
 		except urllib.error.HTTPError as e:
 			print("Not Found : https://www.amiiboapi.com/api/amiibo/?id="+ self.ID)


### PR DESCRIPTION
…d() to ensure the reading JSON responses with newline characters does not cause JSON decoding errors to occur.